### PR TITLE
Dmw/add state file

### DIFF
--- a/allocationFollower.go
+++ b/allocationFollower.go
@@ -1,10 +1,32 @@
 package main
 
 import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
 	"time"
 
 	nomadApi "github.com/hashicorp/nomad/api"
 )
+
+var SaveFormatVersion = 1
+
+type SavePoint struct {
+	NodeID string `json:"node_id"`
+	SaveFormatVersion int `json:"save_format_version"`
+	SavedAllocs map[string]SavedAlloc `json:"saved_allocs"`
+}
+
+type SavedAlloc struct {
+	ID string `json:"alloc_id"`
+	SavedTasks map[string]SavedTask `json:"saved_tasks"`
+}
+
+type SavedTask struct {
+	Name string `json:"task_name"`
+	StdOutOffsets map[string]int64 `json:"stdout_offsets"`
+	StdErrOffsets map[string]int64 `json:"stderr_offsets"`
+}
 
 //AllocationFollower a container for the list of followed allocations
 type AllocationFollower struct {
@@ -40,14 +62,14 @@ func (a *AllocationFollower) SetNodeID() error {
 }
 
 //Start registers and de registers allocation followers
-func (a *AllocationFollower) Start(duration time.Duration) {
+func (a *AllocationFollower) Start(duration time.Duration, savePath string) {
 	logContext := "AllocationFollower.Start"
 	a.Ticker = time.NewTicker(duration)
 
 	go func() {
 		defer a.Ticker.Stop()
-		// TODO add defer a.Stop() ?
 
+		// handle first run special case items
 		a.Nomad.RenewToken()
 		err := a.SetNodeID()
 		if err != nil {
@@ -55,17 +77,36 @@ func (a *AllocationFollower) Start(duration time.Duration) {
 			a.log.Errorf(logContext, "Could not fetch NodeID: %s", err)
 			return
 		}
+		savePoint := a.restoreSavePoint(savePath)
+		err = a.collectAllocations(savePoint)
+		if err != nil {
+			a.log.Debugf(
+				logContext,
+				"Error collecting allocations, first run: %s",
+				err,
+			)
+		}
+		// start routine loop
 		for {
 			select {
 			case <-a.Ticker.C:
-				err := a.collectAllocations()
+				err := a.collectAllocations(nil)
 				if err != nil {
-					a.log.Debugf(logContext, "Error Collecting Allocations: %v", err)
-					// TODO determine if any good way to differentiate 403 from other?
+					a.log.Debugf(
+						logContext,
+						"Error collecting Allocations: %v",
+						err,
+					)
+					// TODO differentiate 403 error from others
 					a.Nomad.RenewToken()
 				}
+				a.createSavePoint(savePath)
 			case <-a.Quit:
-				a.log.Info(logContext, "Stopping Allocation Follower")
+				a.log.Info(
+					logContext,
+					"Stopping Allocation Follower",
+				)
+				// TODO add a.Stop() here?
 				return
 			}
 		}
@@ -81,8 +122,93 @@ func (a *AllocationFollower) Stop() {
 	}
 }
 
-func (a *AllocationFollower) collectAllocations() error {
-	a.log.Debug("AllocationFollower.collectAllocations", "Collecting Allocations")
+func (a *AllocationFollower) createSavePoint(path string) {
+	logContext := "AllocationFollower.buildSavePoint"
+	a.log.Debug(logContext, "Building save file from allocations")
+	savePoint := SavePoint{}
+	savePoint.NodeID = a.NodeID
+	savePoint.SaveFormatVersion = SaveFormatVersion
+	savePoint.SavedAllocs = make(map[string]SavedAlloc, 0)
+	for allocId, alloc := range a.Allocations {
+		allocSave := SavedAlloc{}
+		allocSave.ID = allocId
+		allocSave.SavedTasks = make(map[string]SavedTask, 0)
+
+		for _, task := range alloc.Tasks {
+			taskSave := SavedTask{}
+			taskSave.StdErrOffsets = make(map[string]int64)
+			taskSave.StdOutOffsets = make(map[string]int64)
+			taskSave.Name = task.Task.Name
+			//taskSave.GroupName = task.TaskGroupName
+			taskSave.StdErrOffsets = task.errState.FileOffsets
+			taskSave.StdOutOffsets = task.outState.FileOffsets
+			// TODO add TG name as part of name (prevent task name clash)
+			allocSave.SavedTasks[task.Task.Name] = taskSave
+		}
+		savePoint.SavedAllocs[allocId] = allocSave
+	}
+	data, err := json.Marshal(savePoint)
+	if err != nil {
+		a.log.Errorf(
+			logContext,
+			"Cannot create save file, JSON marshal err: %s",
+			err,
+		)
+		return
+	}
+	err = ioutil.WriteFile(path, data, 0644)
+	if err != nil {
+		a.log.Errorf(
+			logContext,
+			"Cannot create save file, IO error: %s",
+			err,
+		)
+		return
+	}
+}
+
+func (a *AllocationFollower) restoreSavePoint(path string) *SavePoint {
+	logContext := "AllocationFollower.restoreSavePoint"
+	a.log.Debugf(logContext, "Attempting to restore save file from: %s", path)
+	savePoint := SavePoint{}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer file.Close()
+	jsonDecoder := json.NewDecoder(file)
+	err = jsonDecoder.Decode(&savePoint)
+	if err != nil {
+		return nil
+	}
+	if savePoint.NodeID != a.NodeID {
+		a.log.Errorf(
+			logContext,
+			"Cannot restore save from '%s' NodeID differs.",
+			path,
+		)
+		return nil
+	}
+	if savePoint.SaveFormatVersion != SaveFormatVersion {
+		a.log.Errorf(
+			logContext,
+			"Cannot restore save from '%s' version %d != %d",
+			path,
+			savePoint.SaveFormatVersion,
+			SaveFormatVersion,
+		)
+		return nil
+	}
+	a.log.Infof(
+		logContext,
+		"Restored save from file '%s'",
+		path,
+	)
+	return &savePoint
+}
+
+func (a *AllocationFollower) collectAllocations(save *SavePoint) error {
+	a.log.Debug("AllocationFollower.collectAllocations", "Collecting allocations")
 	nodeReader := a.Nomad.Client().Nodes()
 	allocs, _, err := nodeReader.Allocations(a.NodeID, &nomadApi.QueryOptions{})
 
@@ -92,9 +218,17 @@ func (a *AllocationFollower) collectAllocations() error {
 
 	for _, alloc := range allocs {
 		record := a.Allocations[alloc.ID]
-		if record == nil && (alloc.DesiredStatus == "run" || alloc.ClientStatus == "running") {
+		runState := alloc.DesiredStatus == "run" || alloc.ClientStatus == "running"
+		if record == nil && runState {
+			// handle new alloc records w/ potentially saved state
 			falloc := NewFollowedAllocation(alloc, a.Nomad, a.OutChan, a.log)
-			falloc.Start()
+			if save != nil {
+				a.log.Debug("AllocationFollower.collectAllocations", "Restoring saved allocations")
+				savedAlloc := save.SavedAllocs[alloc.ID]
+				falloc.Start(&savedAlloc)
+			} else {
+				falloc.Start(nil)
+			}
 			a.Allocations[alloc.ID] = falloc
 		}
 	}
@@ -111,7 +245,8 @@ func (a *AllocationFollower) collectAllocations() error {
 
 func containsValidAlloc(id string, allocs []*nomadApi.Allocation) bool {
 	for _, alloc := range allocs {
-		if alloc.ID == id && (alloc.DesiredStatus == "run" || alloc.ClientStatus == "running") {
+		runState := alloc.DesiredStatus == "run" || alloc.ClientStatus == "running"
+		if alloc.ID == id && runState {
 			return true
 		}
 	}

--- a/allocationFollower.go
+++ b/allocationFollower.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"time"
@@ -23,7 +24,7 @@ type SavedAlloc struct {
 }
 
 type SavedTask struct {
-	Name string `json:"task_name"`
+	Key string `json:"key"`
 	StdOutOffsets map[string]int64 `json:"stdout_offsets"`
 	StdErrOffsets map[string]int64 `json:"stderr_offsets"`
 }
@@ -138,12 +139,14 @@ func (a *AllocationFollower) createSavePoint(path string) {
 			taskSave := SavedTask{}
 			taskSave.StdErrOffsets = make(map[string]int64)
 			taskSave.StdOutOffsets = make(map[string]int64)
-			taskSave.Name = task.Task.Name
-			//taskSave.GroupName = task.TaskGroupName
+			taskSave.Key = fmt.Sprintf(
+				"%s:%s",
+				task.TaskGroup,
+				task.Task.Name,
+			)
 			taskSave.StdErrOffsets = task.errState.FileOffsets
 			taskSave.StdOutOffsets = task.outState.FileOffsets
-			// TODO add TG name as part of name (prevent task name clash)
-			allocSave.SavedTasks[task.Task.Name] = taskSave
+			allocSave.SavedTasks[taskSave.Key] = taskSave
 		}
 		savePoint.SavedAllocs[allocId] = allocSave
 	}

--- a/followedAllocation.go
+++ b/followedAllocation.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	nomadApi "github.com/hashicorp/nomad/api"
 )
 
@@ -36,10 +37,11 @@ func (f *FollowedAllocation) Start(save *SavedAlloc) {
 	)
 	for _, tg := range f.Alloc.Job.TaskGroups {
 		for _, task := range tg.Tasks {
-			ft := NewFollowedTask(f.Alloc, f.Nomad, f.Quit, task, f.OutputChan, f.log)
+			ft := NewFollowedTask(f.Alloc, *tg.Name, task, f.Nomad, f.Quit, f.OutputChan, f.log)
 			if save != nil {
 				f.log.Debug("FollowedAllocation.Start", "Restoring saved allocation data")
-				savedTask := save.SavedTasks[task.Name]
+				key := fmt.Sprintf("%s:%s", *tg.Name, task.Name)
+				savedTask := save.SavedTasks[key]
 				ft.Start(&savedTask)
 			} else {
 				ft.Start(nil)

--- a/followedAllocation.go
+++ b/followedAllocation.go
@@ -27,7 +27,7 @@ func NewFollowedAllocation(alloc *nomadApi.Allocation, nomad NomadConfig, outCha
 }
 
 //Start starts following an allocation
-func (f *FollowedAllocation) Start() {
+func (f *FollowedAllocation) Start(save *SavedAlloc) {
 	f.log.Debugf(
 		"FollowedAllocation.Start",
 		"Following Allocation: %s ID: %s",
@@ -37,7 +37,13 @@ func (f *FollowedAllocation) Start() {
 	for _, tg := range f.Alloc.Job.TaskGroups {
 		for _, task := range tg.Tasks {
 			ft := NewFollowedTask(f.Alloc, f.Nomad, f.Quit, task, f.OutputChan, f.log)
-			ft.Start()
+			if save != nil {
+				f.log.Debug("FollowedAllocation.Start", "Restoring saved allocation data")
+				savedTask := save.SavedTasks[task.Name]
+				ft.Start(&savedTask)
+			} else {
+				ft.Start(nil)
+			}
 			f.Tasks = append(f.Tasks, ft)
 		}
 	}

--- a/followedTask.go
+++ b/followedTask.go
@@ -211,7 +211,7 @@ func (ft *FollowedTask) Start(save *SavedTask) {
 						ft.OutputChan <- message
 					}
 					// TODO handle log file deletion + truncation events
-					ft.log.Debugf(
+					ft.log.Tracef(
 						logContext,
 						"StdErr Data size: %d Offsets Prior Total: %d Calculated: %d Reported: %d",
 						len(stdErrFrame.Data),
@@ -235,7 +235,7 @@ func (ft *FollowedTask) Start(save *SavedTask) {
 						ft.OutputChan <- message
 					}
 					// TODO handle log file deletion + truncation events
-					ft.log.Debugf(
+					ft.log.Tracef(
 						logContext,
 						"StdOut Data size: %d Offsets Prior Total: %d Calculated: %d Reported: %d",
 						len(stdOutFrame.Data),

--- a/followedTask.go
+++ b/followedTask.go
@@ -54,10 +54,11 @@ func (n *NomadLog) ToJSON() (string, error) {
 //FollowedTask a container for a followed task log process
 type FollowedTask struct {
 	Alloc       *nomadApi.Allocation
-	Nomad       NomadConfig
-	OutputChan  chan string
-	Quit        chan struct{}
+	TaskGroup   string
 	Task        *nomadApi.Task
+	Nomad       NomadConfig
+	Quit        chan struct{}
+	OutputChan  chan string
 	log         Logger
 	logTemplate NomadLog
 	errState    StreamState
@@ -65,13 +66,14 @@ type FollowedTask struct {
 }
 
 //NewFollowedTask creates a new followed task
-func NewFollowedTask(alloc *nomadApi.Allocation, nomad NomadConfig, quit chan struct{}, task *nomadApi.Task, output chan string, logger Logger) *FollowedTask {
+func NewFollowedTask(alloc *nomadApi.Allocation, taskGroup string, task *nomadApi.Task, nomad NomadConfig, quit chan struct{}, output chan string, logger Logger) *FollowedTask {
 	logTemplate := createLogTemplate(alloc, task)
 	return &FollowedTask{
 		Alloc: alloc,
+		TaskGroup: taskGroup,
+		Task: task,
 		Nomad: nomad,
 		Quit: quit,
-		Task: task,
 		OutputChan: output,
 		log: logger,
 		logTemplate: logTemplate,

--- a/service.go
+++ b/service.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"os"
+	"strconv"
 	"time"
 
 	nomadApi "github.com/hashicorp/nomad/api"
@@ -21,12 +22,21 @@ var MAX_LOG_AGE = 1
 var NOMAD_MAX_WAIT = 5 * time.Minute
 var ALLOC_REFRESH_TICK = time.Second * 30
 
-var DEFAULT_VERBOSITY = DEBUG
+var DEFAULT_VERBOSITY = INFO
 
 func main() {
 	//setup the output channel
 	outChan := make(chan string)
-	logger := Logger{verbosity: DEFAULT_VERBOSITY}
+
+	var verbosity LogLevel
+	verbose := os.Getenv("VERBOSE")
+	i, err := strconv.Atoi(verbose)
+	if err != nil {
+		verbosity = DEFAULT_VERBOSITY
+	} else {
+		verbosity = LogLevel(i)
+	}
+	logger := Logger{verbosity: verbosity}
 
 	logFile := os.Getenv("LOG_FILE")
 	if logFile == "" {


### PR DESCRIPTION
- Adds savepoints to have follower pick up logging where it left off
- Eliminates mass duplicates due to follower restarts, or log gaps from interpreting reported stream offsets as actual offsets (rather than 64k block boundaries)
- Tunes back-off delay for collecting from dead/etc tasks to be more aggressive, but reset stdout+stderr error counters together if either recovers
- Adds defaults so follower can be run without environment variables while testing